### PR TITLE
feat: Add integration tests with kind cluster support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ name: "Test"
 run-name: "Test"
 on:
   - pull_request
+  - push
 jobs:
   unit-tests:
     strategy:
@@ -27,10 +28,44 @@ jobs:
         run: |
           make install
 
-      - name: "RUN: Tests"
+      - name: "RUN: Unit Tests"
         env:
           UV_PYTHON: "${{ matrix.python }}"
         run: |
-          ls -l
-          pwd
           make test-unit
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    steps:
+      - name: "SETUP: Checkout repository"
+        uses: actions/checkout@v4
+
+      - name: "SETUP: Install uv"
+        uses: astral-sh/setup-uv@v6
+
+      - name: "SETUP: Install kind"
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: "SETUP: Install kubectl"
+        run: |
+          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x kubectl
+          sudo mv kubectl /usr/local/bin/kubectl
+
+      - name: "SETUP: Install dependencies"
+        run: |
+          make install
+          make install-integration
+
+      - name: "RUN: Integration Tests"
+        run: |
+          make test-integration
+
+      - name: "CLEANUP: Teardown kind cluster"
+        if: always()
+        run: |
+          make test-integration-teardown

--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,11 @@ cython_debug/
 # OS
 .DS_Store
 Thumbs.db
+
+# Integration test artifacts
+tests/integration_tests/*.pem
+tests/integration_tests/*.key
+tests/integration_tests/*.crt
+tests/integration_tests/kubeconfig
+tests/integration_tests/certs/
+.pytest_tmp/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test-unit clean build-wheel all
+.PHONY: help test-unit test-integration test-integration-setup test-integration-teardown test-all clean build-wheel all
 
 ifdef UV_PYTHON
 UV_PYTHON := $(UV_PYTHON)
@@ -11,24 +11,51 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 
-install:
+install:  ## Install development dependencies
 	uv venv
 	uv pip install \
 		--requirements pyproject.toml \
 		--extra dev
 
-test-unit:
+install-integration:  ## Install integration test dependencies
+	uv pip install \
+		--requirements pyproject.toml \
+		--extra integration
+
+test-unit:  ## Run unit tests
 	. .venv/bin/activate
 	uv run pytest tests/unit_tests/ -v
 
-clean:
+test-integration-setup:  ## Setup kind cluster for integration tests
+	@echo "Setting up kind cluster..."
+	@bash tests/integration_tests/scripts/setup_kind.sh
+
+test-integration-teardown:  ## Teardown kind cluster
+	@echo "Tearing down kind cluster..."
+	@bash tests/integration_tests/scripts/teardown_kind.sh
+
+test-integration:  ## Run integration tests (requires Docker)
+	@echo "Running integration tests..."
+	@$(MAKE) test-integration-setup
+	@echo "Installing integration dependencies..."
+	@$(MAKE) install-integration
+	@echo "Running tests..."
+	uv run pytest tests/integration_tests/ -v -m integration
+	@echo "✅ Integration tests complete"
+	@echo "💡 Tip: Run 'make test-integration-teardown' to cleanup the kind cluster"
+
+test-all:  ## Run all tests (unit + integration)
+	@$(MAKE) test-unit
+	@$(MAKE) test-integration
+
+clean:  ## Clean build artifacts
 	rm -rf dist/
 	rm -rf __pycache__/
 	find . -name "*.pyc" -delete
 	find . -name "__pycache__" -type d -exec rm -rf {} +
 	$(MAKE) -C tests clean-test
 
-build-wheel:
+build-wheel:  ## Build wheel package
 	uv build
 
 all: test-unit

--- a/README.md
+++ b/README.md
@@ -2,10 +2,16 @@
 
 A Kubernetes admission validation framework in Python that provides a simple decorator-based approach for creating admission controllers.
 
+## Features
+
+- **Simple decorator-based API** - Use `@validating` decorator to register validation functions
+- **Flexible filtering** - Filter by kind, namespace, apiVersion, or operation using strings or regex
+- **Proper Kubernetes format** - Returns standard AdmissionReview responses
+- **Zero dependencies** - Core framework has no external dependencies
+- **Comprehensive testing** - Unit tests and integration tests with kind
+
 ## TODO
 
-- Return proper Kubernetes admission response dictionary format instead of simple boolean
-- Add integration test with kind
 - Add mutating webhook framework
 
 ## Quick Start
@@ -44,7 +50,7 @@ class AdmissionWebhookHandler(BaseHTTPRequestHandler):
         
         # Process with registry
         registry = Registry()
-        result = registry.validate(admission_request)
+        result = registry.process_admission_review(admission_request)
         
         self.send_response(200)
         self.send_header('Content-Type', 'application/json')
@@ -64,9 +70,17 @@ python webhook_server.py
 
 ## Development
 
+### Running Tests
+
 ```bash
-# Run tests
+# Run unit tests only
 make test-unit
+
+# Run integration tests (requires Docker)
+make test-integration
+
+# Run all tests
+make test-all
 
 # Build wheel
 make build-wheel
@@ -74,3 +88,42 @@ make build-wheel
 # Clean up
 make clean
 ```
+
+### Integration Tests
+
+Integration tests use [kind](https://kind.sigs.k8s.io/) (Kubernetes in Docker) to test the admission webhook in a real Kubernetes cluster.
+
+**Prerequisites:**
+- Docker Desktop (or Docker daemon)
+- kubectl (install from [kubernetes.io](https://kubernetes.io/docs/tasks/tools/))
+- kind (auto-installed by setup script if missing)
+
+**Running integration tests:**
+
+```bash
+# Setup kind cluster (one-time)
+make test-integration-setup
+
+# Run integration tests
+make test-integration
+
+# Cleanup cluster when done
+make test-integration-teardown
+```
+
+**Note:** The kind cluster is reused across test runs for speed. To start fresh, run `make test-integration-teardown` first.
+
+### Test Coverage
+
+- **Unit tests** (`tests/unit_tests/`): Fast tests with no external dependencies
+  - Registry and validator logic
+  - Pre-condition checking
+  - Field extraction
+  - End-to-end validation flows
+
+- **Integration tests** (`tests/integration_tests/`): Real Kubernetes cluster tests
+  - Pod validation acceptance
+  - Pod validation rejection
+  - Multiple validators
+  - Resource limit validation
+  - Webhook server health checks

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,88 @@
+# TODO: Known Issues and Future Improvements
+
+## Pre-condition Skip Behavior
+
+**Issue:** When a validator's pre-conditions don't match the incoming request (e.g., a Service validator checking a Pod), the validation currently returns `False` instead of skipping the validator.
+
+**Current behavior:**
+```python
+@validating("service-validator", kind="Service")
+def validate_service():
+    return True
+
+# When validating a Pod, this returns False instead of skipping
+result = registry.validate_request(pod_request)  # Returns False
+```
+
+**Expected behavior:**
+Validators whose pre-conditions don't match should be skipped entirely, allowing validation to continue with other validators. Only validators with matching pre-conditions should affect the validation result.
+
+**Impact:**
+- Mixed resource type validations fail unexpectedly
+- Requires registering validators very carefully to avoid cross-resource failures
+- Tests show this behavior in `tests/unit_tests/validator_test.py:test_end_to_end_validation_pre_condition_filter`
+
+**Proposed fix:**
+Modify `Registry._check_pre_conditions()` to return a tri-state:
+- `True`: Pre-conditions match, run validator
+- `False`: Pre-conditions explicitly fail, reject request
+- `None` or `"skip"`: Pre-conditions don't match, skip this validator
+
+Then update `validate_request()` to skip validators that return `None/skip` instead of failing validation.
+
+**Priority:** Medium - Affects flexibility but can be worked around by careful validator design
+
+---
+
+## Future Enhancements
+
+### 1. Mutating Webhook Support
+Add support for mutating admission webhooks that can modify resources before they're created/updated.
+
+**API Design:**
+```python
+@mutating(name="add-labels", kind="Pod")
+def add_default_labels(object: dict) -> dict:
+    object.setdefault("metadata", {}).setdefault("labels", {})
+    object["metadata"]["labels"]["added-by"] = "cerberus"
+    return object
+```
+
+### 2. Validation Message Details
+Allow validators to return detailed failure reasons that are included in admission responses.
+
+**API Design:**
+```python
+@validating("pod-validator", kind="Pod")
+def validate_pod(labels) -> tuple[bool, str]:
+    if "app" not in labels:
+        return False, "Pod must have 'app' label"
+    return True, ""
+```
+
+### 3. Async Validator Support
+Support async validators for operations that need to make external API calls.
+
+```python
+@validating("external-validator", kind="Pod")
+async def validate_with_api(object: dict) -> bool:
+    result = await external_service.check(object)
+    return result.is_valid
+```
+
+### 4. Webhook Configuration Generator
+Add CLI tool to generate Kubernetes ValidatingWebhookConfiguration YAML from registered validators.
+
+```bash
+cerberus generate-webhook --url https://webhook.example.com:8443 > webhook-config.yaml
+```
+
+### 5. Prometheus Metrics
+Add built-in metrics for monitoring webhook performance:
+- Request count by kind/operation
+- Validation latency
+- Rejection rate
+- Error rate
+
+### 6. Structured Logging
+Replace print statements with proper structured logging using Python's logging module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,10 @@ dev = [
     "pytest>=7.0.0",
     "ruff>=0.1.0",
     "black>=23.0.0",
-    "pdbpp>=0.10.0", # For Kubernetes client integration tests
+    "pdbpp>=0.10.0",
+]
+integration = [
+    "kubernetes>=28.1.0",  # Kubernetes Python client
+    "requests>=2.31.0",    # HTTP requests for testing
+    "cryptography>=41.0.0", # For generating test certificates
 ]

--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for kube-cerberus admission webhooks."""

--- a/tests/integration_tests/admission_webhook_test.py
+++ b/tests/integration_tests/admission_webhook_test.py
@@ -1,0 +1,277 @@
+"""Integration tests for admission webhooks with kind cluster."""
+import time
+from typing import Dict, Any
+
+import pytest
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+
+from kube_cerberus.validator import validating
+
+
+@pytest.mark.integration
+def test_kind_cluster_available(k8s_client):
+    """Verify kind cluster is running and accessible."""
+    core_api = k8s_client["core"]
+    
+    # List nodes
+    nodes = core_api.list_node()
+    assert len(nodes.items) > 0
+    
+    # Check node is ready
+    node = nodes.items[0]
+    ready_condition = next(
+        (c for c in node.status.conditions if c.type == "Ready"), 
+        None
+    )
+    assert ready_condition is not None
+    assert ready_condition.status == "True"
+
+
+@pytest.mark.integration
+def test_webhook_server_running(webhook_server):
+    """Verify webhook server is running and responsive."""
+    import requests
+    import json
+    import urllib3
+    
+    # Disable SSL warnings for self-signed cert
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    
+    # Create a test admission review
+    admission_review = {
+        "apiVersion": "admission.k8s.io/v1",
+        "kind": "AdmissionReview",
+        "request": {
+            "uid": "test-uid-123",
+            "operation": "CREATE",
+            "object": {
+                "kind": "Pod",
+                "apiVersion": "v1",
+                "metadata": {"name": "test-pod", "labels": {}}
+            }
+        }
+    }
+    
+    # Send request to webhook
+    response = requests.post(
+        f"https://localhost:8443/",
+        json=admission_review,
+        verify=False,  # Self-signed cert
+        timeout=5
+    )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["kind"] == "AdmissionReview"
+    assert "response" in data
+    assert data["response"]["uid"] == "test-uid-123"
+    assert "allowed" in data["response"]
+
+
+@pytest.mark.integration
+def test_pod_validation_success(k8s_client, webhook_server, webhook_configured):
+    """Test that a valid pod is accepted by the webhook."""
+    
+    # Register validator that requires 'app' label
+    @validating("test-pod-validator", kind="Pod")
+    def validate_pod(labels):
+        return "app" in labels
+    
+    # Create valid pod with required label
+    pod = client.V1Pod(
+        metadata=client.V1ObjectMeta(
+            name="valid-test-pod",
+            labels={"app": "myapp"}
+        ),
+        spec=client.V1PodSpec(
+            containers=[
+                client.V1Container(
+                    name="test",
+                    image="nginx:alpine",
+                )
+            ]
+        )
+    )
+    
+    # Should succeed
+    core_api = k8s_client["core"]
+    try:
+        created = core_api.create_namespaced_pod(namespace="default", body=pod)
+        assert created.metadata.name == "valid-test-pod"
+    finally:
+        # Cleanup
+        try:
+            core_api.delete_namespaced_pod(
+                "valid-test-pod", 
+                "default",
+                grace_period_seconds=0
+            )
+        except ApiException:
+            pass
+
+
+@pytest.mark.integration
+def test_pod_validation_rejection(k8s_client, webhook_server, webhook_configured):
+    """Test that an invalid pod is rejected by the webhook."""
+    
+    # Register validator that requires 'required-label'
+    @validating("test-pod-validator", kind="Pod")
+    def validate_pod(labels):
+        return "required-label" in labels
+    
+    # Create invalid pod (missing required label)
+    pod = client.V1Pod(
+        metadata=client.V1ObjectMeta(
+            name="invalid-test-pod",
+            labels={"app": "myapp"}  # Missing 'required-label'
+        ),
+        spec=client.V1PodSpec(
+            containers=[
+                client.V1Container(
+                    name="test", 
+                    image="nginx:alpine"
+                )
+            ]
+        )
+    )
+    
+    # Should fail
+    core_api = k8s_client["core"]
+    with pytest.raises(ApiException) as exc_info:
+        core_api.create_namespaced_pod(namespace="default", body=pod)
+    
+    # Verify rejection
+    assert exc_info.value.status == 403 or exc_info.value.status == 400
+    assert "Validation failed" in str(exc_info.value.body)
+
+
+@pytest.mark.integration
+def test_pod_validation_with_resource_limits(k8s_client, webhook_server, webhook_configured):
+    """Test validation of pod resource limits."""
+    
+    # Register validator that requires resource limits
+    @validating("resource-limit-validator", kind="Pod")
+    def validate_resources(object):
+        containers = object.get("spec", {}).get("containers", [])
+        for container in containers:
+            resources = container.get("resources", {})
+            limits = resources.get("limits", {})
+            if not limits.get("memory") or not limits.get("cpu"):
+                return False
+        return True
+    
+    # Test 1: Valid pod with limits should succeed
+    valid_pod = client.V1Pod(
+        metadata=client.V1ObjectMeta(
+            name="pod-with-limits",
+            labels={"test": "limits"}
+        ),
+        spec=client.V1PodSpec(
+            containers=[
+                client.V1Container(
+                    name="test",
+                    image="nginx:alpine",
+                    resources=client.V1ResourceRequirements(
+                        limits={"memory": "128Mi", "cpu": "100m"}
+                    )
+                )
+            ]
+        )
+    )
+    
+    core_api = k8s_client["core"]
+    try:
+        created = core_api.create_namespaced_pod(namespace="default", body=valid_pod)
+        assert created.metadata.name == "pod-with-limits"
+    finally:
+        try:
+            core_api.delete_namespaced_pod(
+                "pod-with-limits",
+                "default", 
+                grace_period_seconds=0
+            )
+        except ApiException:
+            pass
+    
+    # Test 2: Invalid pod without limits should fail
+    invalid_pod = client.V1Pod(
+        metadata=client.V1ObjectMeta(
+            name="pod-without-limits",
+            labels={"test": "no-limits"}
+        ),
+        spec=client.V1PodSpec(
+            containers=[
+                client.V1Container(
+                    name="test",
+                    image="nginx:alpine"
+                    # No resource limits
+                )
+            ]
+        )
+    )
+    
+    with pytest.raises(ApiException) as exc_info:
+        core_api.create_namespaced_pod(namespace="default", body=invalid_pod)
+    
+    assert exc_info.value.status == 403 or exc_info.value.status == 400
+
+
+@pytest.mark.integration
+def test_multiple_validators(k8s_client, webhook_server, webhook_configured):
+    """Test that multiple validators are all evaluated."""
+    
+    # Register first validator - checks for 'app' label
+    @validating("label-validator", kind="Pod")
+    def validate_labels(labels):
+        return "app" in labels
+    
+    # Register second validator - checks for 'env' label
+    @validating("env-validator", kind="Pod")
+    def validate_env(labels):
+        return "env" in labels
+    
+    # Pod with both labels should succeed
+    valid_pod = client.V1Pod(
+        metadata=client.V1ObjectMeta(
+            name="multi-valid-pod",
+            labels={"app": "myapp", "env": "test"}
+        ),
+        spec=client.V1PodSpec(
+            containers=[
+                client.V1Container(name="test", image="nginx:alpine")
+            ]
+        )
+    )
+    
+    core_api = k8s_client["core"]
+    try:
+        created = core_api.create_namespaced_pod(namespace="default", body=valid_pod)
+        assert created.metadata.name == "multi-valid-pod"
+    finally:
+        try:
+            core_api.delete_namespaced_pod(
+                "multi-valid-pod",
+                "default",
+                grace_period_seconds=0
+            )
+        except ApiException:
+            pass
+    
+    # Pod missing 'env' label should fail
+    invalid_pod = client.V1Pod(
+        metadata=client.V1ObjectMeta(
+            name="multi-invalid-pod",
+            labels={"app": "myapp"}  # Missing 'env'
+        ),
+        spec=client.V1PodSpec(
+            containers=[
+                client.V1Container(name="test", image="nginx:alpine")
+            ]
+        )
+    )
+    
+    with pytest.raises(ApiException) as exc_info:
+        core_api.create_namespaced_pod(namespace="default", body=invalid_pod)
+    
+    assert exc_info.value.status == 403 or exc_info.value.status == 400

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,0 +1,223 @@
+"""Pytest fixtures for integration tests."""
+import os
+import subprocess
+import time
+import tempfile
+import base64
+import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+
+from tests.integration_tests.webhook_server import WebhookServer
+from kube_cerberus.registry import REGISTRY
+
+
+@pytest.fixture(scope="session")
+def kind_cluster():
+    """
+    Create and manage a kind cluster for tests.
+    
+    The cluster is created once at session start and reused for all tests.
+    Cleanup is manual via 'make test-integration-teardown' to allow reusing
+    cluster across multiple test runs for speed.
+    """
+    cluster_name = "cerberus-test"
+    test_dir = Path(__file__).parent
+    setup_script = test_dir / "scripts" / "setup_kind.sh"
+    
+    # Setup cluster
+    env = os.environ.copy()
+    env["CLUSTER_NAME"] = cluster_name
+    
+    try:
+        subprocess.run(
+            ["bash", str(setup_script)],
+            check=True,
+            env=env,
+            capture_output=True,
+            text=True
+        )
+    except subprocess.CalledProcessError as e:
+        pytest.fail(f"Failed to setup kind cluster: {e.stderr}")
+    
+    # Load kubeconfig
+    try:
+        config.load_kube_config(context=f"kind-{cluster_name}")
+    except Exception as e:
+        pytest.fail(f"Failed to load kubeconfig: {e}")
+    
+    yield {
+        "name": cluster_name,
+        "context": f"kind-{cluster_name}"
+    }
+    
+    # Note: Cleanup is manual via make test-integration-teardown
+    # This allows reusing cluster across multiple test runs for speed
+
+
+@pytest.fixture(scope="session")
+def webhook_certs(tmp_path_factory):
+    """Generate self-signed certificates for webhook server."""
+    from cryptography import x509
+    from cryptography.x509.oid import NameOID
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives import serialization
+    
+    cert_dir = tmp_path_factory.mktemp("certs")
+    
+    # Generate private key
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+    
+    # Generate certificate
+    subject = issuer = x509.Name([
+        x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Cerberus Test"),
+        x509.NameAttribute(NameOID.COMMON_NAME, "webhook-server"),
+    ])
+    
+    cert = x509.CertificateBuilder().subject_name(
+        subject
+    ).issuer_name(
+        issuer
+    ).public_key(
+        private_key.public_key()
+    ).serial_number(
+        x509.random_serial_number()
+    ).not_valid_before(
+        datetime.datetime.utcnow()
+    ).not_valid_after(
+        datetime.datetime.utcnow() + datetime.timedelta(days=1)
+    ).add_extension(
+        x509.SubjectAlternativeName([
+            x509.DNSName("localhost"),
+            x509.DNSName("webhook-server"),
+            x509.DNSName("host.docker.internal"),
+        ]),
+        critical=False,
+    ).sign(private_key, hashes.SHA256())
+    
+    # Write files
+    key_file = cert_dir / "server.key"
+    cert_file = cert_dir / "server.crt"
+    
+    with open(key_file, "wb") as f:
+        f.write(private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption()
+        ))
+    
+    with open(cert_file, "wb") as f:
+        f.write(cert.public_bytes(serialization.Encoding.PEM))
+    
+    # Get CA bundle (self-signed, so cert is CA)
+    ca_bundle_pem = cert.public_bytes(serialization.Encoding.PEM)
+    ca_bundle_b64 = base64.b64encode(ca_bundle_pem).decode('utf-8')
+    
+    return {
+        "cert_file": str(cert_file),
+        "key_file": str(key_file),
+        "ca_bundle_pem": ca_bundle_pem.decode(),
+        "ca_bundle_b64": ca_bundle_b64,
+    }
+
+
+@pytest.fixture(scope="session")
+def webhook_server(webhook_certs):
+    """Start webhook server for tests."""
+    server = WebhookServer(
+        host='0.0.0.0',
+        port=8443,
+        cert_file=webhook_certs["cert_file"],
+        key_file=webhook_certs["key_file"],
+    )
+    
+    server.start()
+    time.sleep(2)  # Give server time to start
+    
+    yield server
+    
+    server.stop()
+
+
+@pytest.fixture(scope="function", autouse=True)
+def clean_registry():
+    """Clean registry before each test."""
+    REGISTRY.validating_hooks.clear()
+    yield
+    REGISTRY.validating_hooks.clear()
+
+
+@pytest.fixture(scope="session")
+def k8s_client(kind_cluster):
+    """Get Kubernetes API client."""
+    return {
+        "core": client.CoreV1Api(),
+        "apps": client.AppsV1Api(),
+        "admission": client.AdmissionregistrationV1Api(),
+    }
+
+
+@pytest.fixture(scope="function")
+def webhook_configured(k8s_client, webhook_certs):
+    """
+    Deploy ValidatingWebhookConfiguration.
+    
+    This fixture is function-scoped and cleans up after each test.
+    """
+    admission_api = k8s_client["admission"]
+    webhook_name = "cerberus-test-webhook"
+    
+    # Create webhook configuration
+    webhook_config = client.V1ValidatingWebhookConfiguration(
+        metadata=client.V1ObjectMeta(name=webhook_name),
+        webhooks=[
+            client.V1ValidatingWebhook(
+                name="test.cerberus.k8s.io",
+                client_config=client.AdmissionregistrationV1WebhookClientConfig(
+                    url="https://host.docker.internal:8443",  # kind can reach host
+                    ca_bundle=webhook_certs["ca_bundle_b64"].encode()
+                ),
+                rules=[
+                    client.V1RuleWithOperations(
+                        operations=["CREATE", "UPDATE"],
+                        api_groups=[""],
+                        api_versions=["v1"],
+                        resources=["pods"]
+                    )
+                ],
+                admission_review_versions=["v1"],
+                side_effects="None",
+                timeout_seconds=10,
+                failure_policy="Fail",
+            )
+        ]
+    )
+    
+    try:
+        admission_api.create_validating_webhook_configuration(webhook_config)
+    except ApiException as e:
+        if e.status == 409:  # Already exists
+            admission_api.patch_validating_webhook_configuration(
+                webhook_name, webhook_config
+            )
+        else:
+            raise
+    
+    time.sleep(3)  # Wait for webhook to be ready
+    
+    yield webhook_config
+    
+    # Cleanup
+    try:
+        admission_api.delete_validating_webhook_configuration(webhook_name)
+    except ApiException:
+        pass  # Already deleted

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -91,7 +91,7 @@ def kind_cluster():
 
 
 @pytest.fixture(scope="session")
-def webhook_certs(tmp_path_factory):
+def webhook_certs(tmp_path_factory, kind_cluster):
     """Generate self-signed certificates for webhook server."""
     from cryptography import x509
     from cryptography.x509.oid import NameOID

--- a/tests/integration_tests/scripts/setup_kind.sh
+++ b/tests/integration_tests/scripts/setup_kind.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Setup kind cluster for integration tests
+# Works both locally and in CI
+
+set -e
+
+CLUSTER_NAME="${CLUSTER_NAME:-cerberus-test}"
+KIND_CONFIG="${KIND_CONFIG:-}"
+
+echo "🔧 Setting up kind cluster: $CLUSTER_NAME"
+
+# Check if kind is installed
+if ! command -v kind &> /dev/null; then
+    echo "❌ kind not found. Installing..."
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-darwin-amd64
+    else
+        echo "❌ Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+    chmod +x ./kind
+    sudo mv ./kind /usr/local/bin/kind
+    echo "✅ kind installed"
+fi
+
+# Check if kubectl is installed
+if ! command -v kubectl &> /dev/null; then
+    echo "❌ kubectl not found. Please install kubectl first."
+    echo "   Visit: https://kubernetes.io/docs/tasks/tools/"
+    exit 1
+fi
+
+# Check if cluster already exists
+if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+    echo "✅ Cluster $CLUSTER_NAME already exists"
+else
+    echo "🚀 Creating kind cluster..."
+    
+    # Create cluster with extra port mappings for webhook server
+    cat <<EOF | kind create cluster --name "$CLUSTER_NAME" --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 443
+    hostPort: 6443
+    protocol: TCP
+EOF
+    
+    echo "⏳ Waiting for cluster to be ready..."
+    kubectl wait --for=condition=Ready nodes --all --timeout=300s --context "kind-${CLUSTER_NAME}"
+fi
+
+# Set kubectl context
+kubectl config use-context "kind-${CLUSTER_NAME}"
+
+echo "✅ Kind cluster ready!"
+kubectl cluster-info --context "kind-${CLUSTER_NAME}"
+kubectl get nodes

--- a/tests/integration_tests/scripts/teardown_kind.sh
+++ b/tests/integration_tests/scripts/teardown_kind.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Teardown kind cluster
+
+set -e
+
+CLUSTER_NAME="${CLUSTER_NAME:-cerberus-test}"
+
+echo "🧹 Tearing down kind cluster: $CLUSTER_NAME"
+
+if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+    kind delete cluster --name "$CLUSTER_NAME"
+    echo "✅ Cluster deleted"
+else
+    echo "ℹ️  Cluster $CLUSTER_NAME does not exist"
+fi

--- a/tests/integration_tests/webhook_server.py
+++ b/tests/integration_tests/webhook_server.py
@@ -1,0 +1,108 @@
+"""
+Test webhook server for integration tests.
+Implements a complete HTTPS admission webhook server.
+"""
+import json
+import ssl
+import threading
+import logging
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+from typing import Optional
+
+from kube_cerberus.registry import REGISTRY
+
+
+logger = logging.getLogger(__name__)
+
+
+class AdmissionWebhookHandler(BaseHTTPRequestHandler):
+    """HTTP handler for Kubernetes admission webhook requests."""
+    
+    def log_message(self, format, *args):
+        """Override to use proper logging."""
+        logger.info(format % args)
+    
+    def do_POST(self):
+        """Handle POST requests with AdmissionReview."""
+        try:
+            content_length = int(self.headers['Content-Length'])
+            body = self.rfile.read(content_length)
+            admission_review = json.loads(body)
+            
+            request_uid = admission_review.get('request', {}).get('uid', 'unknown')
+            logger.info(f"Received admission request: {request_uid}")
+            
+            # Process with registry
+            response = REGISTRY.process_admission_review(admission_review)
+            
+            # Send response
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps(response).encode())
+            
+            allowed = response['response']['allowed']
+            logger.info(f"Sent response for {request_uid}: allowed={allowed}")
+            
+        except Exception as e:
+            logger.error(f"Error processing request: {e}", exc_info=True)
+            self.send_response(500)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            error_response = {
+                "error": str(e)
+            }
+            self.wfile.write(json.dumps(error_response).encode())
+
+
+class WebhookServer:
+    """Manages the webhook server lifecycle."""
+    
+    def __init__(
+        self, 
+        host: str = '0.0.0.0', 
+        port: int = 8443, 
+        cert_file: Optional[str] = None, 
+        key_file: Optional[str] = None
+    ):
+        self.host = host
+        self.port = port
+        self.cert_file = cert_file
+        self.key_file = key_file
+        self.server: Optional[HTTPServer] = None
+        self.thread: Optional[threading.Thread] = None
+    
+    def start(self):
+        """Start the webhook server in a background thread."""
+        self.server = HTTPServer((self.host, self.port), AdmissionWebhookHandler)
+        
+        # Setup SSL if certificates provided
+        if self.cert_file and self.key_file:
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            context.load_cert_chain(self.cert_file, self.key_file)
+            self.server.socket = context.wrap_socket(
+                self.server.socket, 
+                server_side=True
+            )
+            logger.info(f"Webhook server configured with SSL")
+        
+        self.thread = threading.Thread(
+            target=self.server.serve_forever, 
+            daemon=True
+        )
+        self.thread.start()
+        logger.info(f"Webhook server started on {self.host}:{self.port}")
+    
+    def stop(self):
+        """Stop the webhook server."""
+        if self.server:
+            self.server.shutdown()
+            self.server.server_close()
+            logger.info("Webhook server stopped")
+    
+    @property
+    def url(self) -> str:
+        """Get the server URL."""
+        protocol = "https" if self.cert_file else "http"
+        return f"{protocol}://{self.host}:{self.port}"


### PR DESCRIPTION
## Summary
- add kind-backed integration test suite with webhook server fixtures and scripts
- wire workflow and Makefile targets for unit/integration test runs and setup/teardown
- document integration testing flow and update registry API for AdmissionReview handling