### PR TITLE
feat: implement TODO roadmap features and tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,88 +1,13 @@
-# TODO: Known Issues and Future Improvements
+# TODO Status
 
-## Pre-condition Skip Behavior
+All previously listed TODO items have been implemented:
 
-**Issue:** When a validator's pre-conditions don't match the incoming request (e.g., a Service validator checking a Pod), the validation currently returns `False` instead of skipping the validator.
+- [x] Pre-condition skip behavior with tri-state handling (`match` / `reject` / `skip`)
+- [x] Mutating webhook framework (`@mutating` and mutating AdmissionReview processing)
+- [x] Validation message details via validator return type `(bool, str)`
+- [x] Async hook support (validators and mutators)
+- [x] Webhook configuration generator CLI (`cerberus generate-webhook`)
+- [x] Prometheus metrics export (`Registry.metrics_text()`)
+- [x] Structured logging (replacing `print`-based runtime diagnostics)
 
-**Current behavior:**
-```python
-@validating("service-validator", kind="Service")
-def validate_service():
-    return True
-
-# When validating a Pod, this returns False instead of skipping
-result = registry.validate_request(pod_request)  # Returns False
-```
-
-**Expected behavior:**
-Validators whose pre-conditions don't match should be skipped entirely, allowing validation to continue with other validators. Only validators with matching pre-conditions should affect the validation result.
-
-**Impact:**
-- Mixed resource type validations fail unexpectedly
-- Requires registering validators very carefully to avoid cross-resource failures
-- Tests show this behavior in `tests/unit_tests/validator_test.py:test_end_to_end_validation_pre_condition_filter`
-
-**Proposed fix:**
-Modify `Registry._check_pre_conditions()` to return a tri-state:
-- `True`: Pre-conditions match, run validator
-- `False`: Pre-conditions explicitly fail, reject request
-- `None` or `"skip"`: Pre-conditions don't match, skip this validator
-
-Then update `validate_request()` to skip validators that return `None/skip` instead of failing validation.
-
-**Priority:** Medium - Affects flexibility but can be worked around by careful validator design
-
----
-
-## Future Enhancements
-
-### 1. Mutating Webhook Support
-Add support for mutating admission webhooks that can modify resources before they're created/updated.
-
-**API Design:**
-```python
-@mutating(name="add-labels", kind="Pod")
-def add_default_labels(object: dict) -> dict:
-    object.setdefault("metadata", {}).setdefault("labels", {})
-    object["metadata"]["labels"]["added-by"] = "cerberus"
-    return object
-```
-
-### 2. Validation Message Details
-Allow validators to return detailed failure reasons that are included in admission responses.
-
-**API Design:**
-```python
-@validating("pod-validator", kind="Pod")
-def validate_pod(labels) -> tuple[bool, str]:
-    if "app" not in labels:
-        return False, "Pod must have 'app' label"
-    return True, ""
-```
-
-### 3. Async Validator Support
-Support async validators for operations that need to make external API calls.
-
-```python
-@validating("external-validator", kind="Pod")
-async def validate_with_api(object: dict) -> bool:
-    result = await external_service.check(object)
-    return result.is_valid
-```
-
-### 4. Webhook Configuration Generator
-Add CLI tool to generate Kubernetes ValidatingWebhookConfiguration YAML from registered validators.
-
-```bash
-cerberus generate-webhook --url https://webhook.example.com:8443 > webhook-config.yaml
-```
-
-### 5. Prometheus Metrics
-Add built-in metrics for monitoring webhook performance:
-- Request count by kind/operation
-- Validation latency
-- Rejection rate
-- Error rate
-
-### 6. Structured Logging
-Replace print statements with proper structured logging using Python's logging module.
+Unit test coverage for these features lives in `tests/unit_tests/todo_features_test.py`.

--- a/kube_cerberus/__init__.py
+++ b/kube_cerberus/__init__.py
@@ -6,9 +6,12 @@ for registering validation functions.
 """
 
 from .registry import Registry
-from .validator import validating
+from .validator import mutating, validating
+from .webhook_config import generate_webhook_configuration_yaml
 
 __all__ = [
-    'Registry',
-    'validating'
+    "Registry",
+    "validating",
+    "mutating",
+    "generate_webhook_configuration_yaml",
 ]

--- a/kube_cerberus/cli.py
+++ b/kube_cerberus/cli.py
@@ -1,0 +1,59 @@
+"""Command line utilities for kube-cerberus."""
+
+from __future__ import annotations
+
+import argparse
+
+from .registry import REGISTRY
+from .webhook_config import generate_webhook_configuration_yaml
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="cerberus")
+    subparsers = parser.add_subparsers(dest="command")
+
+    generate_parser = subparsers.add_parser(
+        "generate-webhook",
+        help="Generate Kubernetes webhook configuration YAML from registered hooks.",
+    )
+    generate_parser.add_argument("--url", required=True, help="Webhook service URL.")
+    generate_parser.add_argument(
+        "--name",
+        default="cerberus-webhook",
+        help="Base name for generated webhook configuration resources.",
+    )
+    generate_parser.add_argument(
+        "--mode",
+        choices=["validating", "mutating", "both"],
+        default="validating",
+        help="Which webhook configuration type(s) to generate.",
+    )
+    generate_parser.add_argument(
+        "--ca-bundle",
+        default=None,
+        help="Optional base64-encoded CA bundle.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "generate-webhook":
+        yaml_output = generate_webhook_configuration_yaml(
+            registry=REGISTRY,
+            url=args.url,
+            name=args.name,
+            mode=args.mode,
+            ca_bundle=args.ca_bundle,
+        )
+        print(yaml_output, end="")
+        return 0
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kube_cerberus/registry.py
+++ b/kube_cerberus/registry.py
@@ -1,65 +1,97 @@
-from typing import Any, Callable
-from dataclasses import dataclass
+from __future__ import annotations
+
+import asyncio
+import base64
+import copy
+import inspect
+import json
+import logging
+import threading
+import time
 import types
+from dataclasses import dataclass, field
+from typing import Any, Callable, Literal
 
 
-def create_field_cache(request: dict[str, Any]) -> tuple[dict[str, types.MappingProxyType], Any]:
-    """Create a cache for extracted fields to avoid re-computation"""
-    field_cache = {}
-    
-    def get_cached_field(field_name: str, field_path: list[str]):
+logger = logging.getLogger(__name__)
+
+PreConditionState = Literal["match", "reject", "skip"]
+
+
+def create_field_cache(
+    request: dict[str, Any],
+) -> tuple[dict[str, Any], Callable[[str, list[str]], Any]]:
+    """Create a cache for extracted fields to avoid re-computation."""
+    field_cache: dict[str, Any] = {}
+
+    def get_cached_field(field_name: str, field_path: list[str]) -> Any:
         cache_key = field_name
         if cache_key not in field_cache:
             if field_name == "raw_object":
-                # Special case: pass the entire request as immutable 'raw_object'
+                # Pass the entire request as immutable raw input.
                 field_cache[cache_key] = types.MappingProxyType(request)
             else:
-                # Navigate to the specific field
-                current = request
+                current: Any = request
                 for path_part in field_path:
-                    current = current.get(path_part, {})
-                # If we ended up with a dict, make it immutable; otherwise use empty immutable dict
+                    if isinstance(current, dict):
+                        current = current.get(path_part, {})
+                    else:
+                        current = {}
+                        break
+
                 if isinstance(current, dict):
                     field_cache[cache_key] = types.MappingProxyType(current)
                 else:
-                    field_cache[cache_key] = types.MappingProxyType({})
+                    field_cache[cache_key] = current
         return field_cache[cache_key]
-    
+
     return field_cache, get_cached_field
 
 
 def validate_request_structure(request: dict[str, Any]) -> None:
-    """Validate the structure of the incoming request"""
+    """Validate the structure of the incoming request."""
     if not isinstance(request, dict):
         raise ValueError("Request must be a dictionary")
-    
+
     if "object" not in request:
         raise ValueError("Request must contain an 'object' field")
-    
+
     if not isinstance(request["object"], dict):
         raise ValueError("Request 'object' field must be a dictionary")
-    
-    # Validate that object has required Kubernetes fields
+
     obj = request["object"]
     if "kind" not in obj:
         raise ValueError("Request object must contain a 'kind' field")
-    
+
     if "apiVersion" not in obj:
         raise ValueError("Request object must contain an 'apiVersion' field")
-    
-    # Validate metadata structure if present
+
     if "metadata" in obj and not isinstance(obj["metadata"], dict):
         raise ValueError("Request object 'metadata' field must be a dictionary")
 
 
 @dataclass
 class Validator:
-    pre_conditions: list[
-        Callable[[dict[str, Any]], bool]
-    ]  # add list of kind=Pod,namespace=.. conditions, which must be true, before running user code
-    user_function: Callable[..., bool]
+    pre_conditions: list[Callable[[dict[str, Any]], Any]]
+    user_function: Callable[..., Any]
     name: str
-    extract_fields: dict[str, list[str]]  # field name -> path to extract from request
+    extract_fields: dict[str, list[str]]
+    kind_filter: Any = None
+    namespace_filter: Any = None
+    api_version_filter: Any = None
+    operation_filter: Any = None
+
+
+@dataclass
+class Mutator:
+    pre_conditions: list[Callable[[dict[str, Any]], Any]]
+    user_function: Callable[..., Any]
+    name: str
+    extract_fields: dict[str, list[str]]
+    kind_filter: Any = None
+    namespace_filter: Any = None
+    api_version_filter: Any = None
+    operation_filter: Any = None
 
 
 @dataclass
@@ -68,166 +100,463 @@ class ValidatingHook:
     validators: list[Validator]
 
 
+@dataclass
+class MutatingHook:
+    name: str
+    mutators: list[Mutator]
+
+
+@dataclass
+class ValidationResult:
+    allowed: bool
+    message: str = ""
+
+
+@dataclass
+class MutationResult:
+    allowed: bool
+    mutated_object: dict[str, Any]
+    message: str = ""
+
+
+@dataclass
+class RegistryMetrics:
+    request_count: dict[tuple[str, str], int] = field(default_factory=dict)
+    rejection_count: dict[tuple[str, str], int] = field(default_factory=dict)
+    error_count: dict[tuple[str, str], int] = field(default_factory=dict)
+    latency_sum: dict[tuple[str, str], float] = field(default_factory=dict)
+    latency_count: dict[tuple[str, str], int] = field(default_factory=dict)
+
+    def observe(
+        self,
+        *,
+        kind: str,
+        operation: str,
+        allowed: bool,
+        errored: bool,
+        latency_seconds: float,
+    ) -> None:
+        label = (kind, operation)
+        self.request_count[label] = self.request_count.get(label, 0) + 1
+        self.latency_sum[label] = self.latency_sum.get(label, 0.0) + latency_seconds
+        self.latency_count[label] = self.latency_count.get(label, 0) + 1
+
+        if errored:
+            self.error_count[label] = self.error_count.get(label, 0) + 1
+        elif not allowed:
+            self.rejection_count[label] = self.rejection_count.get(label, 0) + 1
+
+    @staticmethod
+    def _escape(value: str) -> str:
+        return value.replace("\\", "\\\\").replace('"', '\\"')
+
+    def _render_metric(self, metric_name: str, values: dict[tuple[str, str], Any]) -> list[str]:
+        lines = []
+        for (kind, operation), value in sorted(values.items()):
+            escaped_kind = self._escape(kind)
+            escaped_operation = self._escape(operation)
+            lines.append(
+                f'{metric_name}{{kind="{escaped_kind}",operation="{escaped_operation}"}} {value}'
+            )
+        return lines
+
+    def render_prometheus(self) -> str:
+        lines = [
+            "# HELP kube_cerberus_requests_total Total admission requests processed.",
+            "# TYPE kube_cerberus_requests_total counter",
+            *self._render_metric("kube_cerberus_requests_total", self.request_count),
+            "# HELP kube_cerberus_rejections_total Total requests rejected by hooks.",
+            "# TYPE kube_cerberus_rejections_total counter",
+            *self._render_metric("kube_cerberus_rejections_total", self.rejection_count),
+            "# HELP kube_cerberus_errors_total Total request processing errors.",
+            "# TYPE kube_cerberus_errors_total counter",
+            *self._render_metric("kube_cerberus_errors_total", self.error_count),
+            "# HELP kube_cerberus_validation_latency_seconds_total Total validation latency in seconds.",
+            "# TYPE kube_cerberus_validation_latency_seconds_total counter",
+            *self._render_metric("kube_cerberus_validation_latency_seconds_total", self.latency_sum),
+            "# HELP kube_cerberus_validation_latency_seconds_count Total validation latency samples.",
+            "# TYPE kube_cerberus_validation_latency_seconds_count counter",
+            *self._render_metric("kube_cerberus_validation_latency_seconds_count", self.latency_count),
+        ]
+        return "\n".join(lines) + "\n"
+
+
+def _json_pointer_escape(path: str) -> str:
+    return path.replace("~", "~0").replace("/", "~1")
+
+
+def _create_json_patch(
+    source: Any,
+    target: Any,
+    path: str = "",
+) -> list[dict[str, Any]]:
+    if source == target:
+        return []
+
+    if isinstance(source, dict) and isinstance(target, dict):
+        patch = []
+        for key in sorted(source.keys() - target.keys()):
+            child_path = f"{path}/{_json_pointer_escape(key)}"
+            patch.append({"op": "remove", "path": child_path})
+        for key in sorted(target.keys() - source.keys()):
+            child_path = f"{path}/{_json_pointer_escape(key)}"
+            patch.append({"op": "add", "path": child_path, "value": target[key]})
+        for key in sorted(source.keys() & target.keys()):
+            child_path = f"{path}/{_json_pointer_escape(key)}"
+            patch.extend(_create_json_patch(source[key], target[key], child_path))
+        return patch
+
+    if isinstance(source, list) and isinstance(target, list):
+        return [{"op": "replace", "path": path or "", "value": target}]
+
+    return [{"op": "replace", "path": path or "", "value": target}]
+
+
 class Registry:
     def __init__(self):
         self.validating_hooks: dict[str, ValidatingHook] = {}
+        self.mutating_hooks: dict[str, MutatingHook] = {}
+        self.metrics = RegistryMetrics()
 
     def add_validating_webhook(self, hook: ValidatingHook):
         if hook.name in self.validating_hooks:
             raise Exception(f"Duplicate hook.name={hook.name}")
         self.validating_hooks[hook.name] = hook
 
-    def _check_pre_conditions(self, validator: Validator, request: dict[str, Any]) -> bool:
-        """Check all pre-conditions for a validator"""
-        for pre_condition in validator.pre_conditions:
-            if not pre_condition(request):
-                print(f"Pre-condition failed for {validator.name}")
+    def add_mutating_webhook(self, hook: MutatingHook):
+        if hook.name in self.mutating_hooks:
+            raise Exception(f"Duplicate hook.name={hook.name}")
+        self.mutating_hooks[hook.name] = hook
+
+    @staticmethod
+    def _normalize_pre_condition_result(result: Any) -> PreConditionState:
+        if result is True:
+            return "match"
+        if result is False:
+            return "reject"
+        if result is None:
+            return "skip"
+
+        if isinstance(result, str):
+            value = result.strip().lower()
+            if value in {"match", "allow", "pass", "true"}:
+                return "match"
+            if value in {"skip", "none", "ignore"}:
+                return "skip"
+            if value in {"reject", "deny", "false"}:
+                return "reject"
+            return "reject"
+
+        return "match" if bool(result) else "reject"
+
+    def _check_pre_conditions(
+        self,
+        hook_or_name: Validator | Mutator | str,
+        pre_conditions_or_request: list[Callable[[dict[str, Any]], Any]] | dict[str, Any],
+        request: dict[str, Any] | None = None,
+    ) -> bool | None:
+        """Return True=run, False=reject, None=skip."""
+        if request is None:
+            hook = hook_or_name
+            if not isinstance(hook, (Validator, Mutator)):
+                raise TypeError("hook must be Validator or Mutator when request is omitted")
+            hook_name = hook.name
+            pre_conditions = hook.pre_conditions
+            request = pre_conditions_or_request
+            if not isinstance(request, dict):
+                raise TypeError("request must be a dictionary")
+        else:
+            hook_name = str(hook_or_name)
+            pre_conditions = pre_conditions_or_request
+            if not isinstance(pre_conditions, list):
+                raise TypeError("pre_conditions must be a list")
+
+        skipped = False
+        for pre_condition in pre_conditions:
+            try:
+                state = self._normalize_pre_condition_result(pre_condition(request))
+            except Exception:
+                logger.exception("Pre-condition raised for hook '%s'", hook_name)
                 return False
+
+            if state == "reject":
+                logger.info("Pre-condition rejected request for hook '%s'", hook_name)
+                return False
+            if state == "skip":
+                skipped = True
+
+        if skipped:
+            return None
         return True
 
-    def _extract_validator_kwargs(self, validator: Validator, get_cached_field) -> dict[str, Any]:
-        """Extract kwargs for a validator using the field cache"""
+    def _extract_validator_kwargs(
+        self,
+        hook: Validator | Mutator,
+        get_cached_field: Callable[[str, list[str]], Any],
+    ) -> dict[str, Any]:
         kwargs = {}
-        for field_name, field_path in validator.extract_fields.items():
+        for field_name, field_path in hook.extract_fields.items():
             kwargs[field_name] = get_cached_field(field_name, field_path)
         return kwargs
 
-    def _run_validator(self, validator: Validator, kwargs: dict[str, Any]) -> bool:
-        """Run a single validator and return the result"""
-        response = validator.user_function(**kwargs)
-        if not isinstance(response, bool):
-            print("no bool returned, assuming False")
-            return False
+    @staticmethod
+    def _run_coroutine_sync(awaitable: Any) -> Any:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(awaitable)
 
-        if response == False:
-            print(f"{validator.name} returned false")
-            return False
-        return True
+        result: dict[str, Any] = {}
+        error: dict[str, BaseException] = {}
+
+        def _runner() -> None:
+            loop = asyncio.new_event_loop()
+            try:
+                result["value"] = loop.run_until_complete(awaitable)
+            except BaseException as exc:  # noqa: BLE001
+                error["error"] = exc
+            finally:
+                loop.close()
+
+        thread = threading.Thread(target=_runner, daemon=True)
+        thread.start()
+        thread.join()
+
+        if "error" in error:
+            raise error["error"]
+        return result.get("value")
+
+    def _execute_user_function(self, user_function: Callable[..., Any], kwargs: dict[str, Any]) -> Any:
+        response = user_function(**kwargs)
+        if inspect.isawaitable(response):
+            return self._run_coroutine_sync(response)
+        return response
+
+    def _run_validator(self, validator: Validator, kwargs: dict[str, Any]) -> ValidationResult:
+        try:
+            response = self._execute_user_function(validator.user_function, kwargs)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Validator '%s' raised an exception", validator.name)
+            return ValidationResult(
+                allowed=False,
+                message=f"Validation error in '{validator.name}': {exc}",
+            )
+
+        if isinstance(response, bool):
+            if response:
+                return ValidationResult(allowed=True)
+            return ValidationResult(
+                allowed=False,
+                message=f"Validation failed by '{validator.name}'",
+            )
+
+        if (
+            isinstance(response, tuple)
+            and len(response) == 2
+            and isinstance(response[0], bool)
+            and isinstance(response[1], str)
+        ):
+            allowed, message = response
+            if allowed:
+                return ValidationResult(allowed=True)
+            return ValidationResult(
+                allowed=False,
+                message=message or f"Validation failed by '{validator.name}'",
+            )
+
+        logger.warning(
+            "Validator '%s' returned invalid type '%s'",
+            validator.name,
+            type(response).__name__,
+        )
+        return ValidationResult(
+            allowed=False,
+            message=f"Validator '{validator.name}' returned invalid result type",
+        )
+
+    def _run_mutator(
+        self,
+        mutator: Mutator,
+        kwargs: dict[str, Any],
+        current_object: dict[str, Any],
+    ) -> MutationResult:
+        try:
+            response = self._execute_user_function(mutator.user_function, kwargs)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Mutator '%s' raised an exception", mutator.name)
+            return MutationResult(
+                allowed=False,
+                mutated_object=current_object,
+                message=f"Mutation error in '{mutator.name}': {exc}",
+            )
+
+        if not isinstance(response, dict):
+            logger.warning(
+                "Mutator '%s' returned invalid type '%s'",
+                mutator.name,
+                type(response).__name__,
+            )
+            return MutationResult(
+                allowed=False,
+                mutated_object=current_object,
+                message=f"Mutator '{mutator.name}' must return a dictionary",
+            )
+
+        return MutationResult(allowed=True, mutated_object=response)
+
+    @staticmethod
+    def _request_labels(request: dict[str, Any]) -> tuple[str, str]:
+        obj = request.get("object", {})
+        kind = obj.get("kind", "unknown") if isinstance(obj, dict) else "unknown"
+        operation = request.get("operation", "unknown")
+        return str(kind), str(operation)
+
+    def validate_request_detailed(self, request: dict[str, Any]) -> ValidationResult:
+        """Evaluate all validating hooks and return detailed result."""
+        kind, operation = self._request_labels(request)
+        start = time.perf_counter()
+        allowed = False
+        errored = False
+
+        try:
+            validate_request_structure(request)
+            _, get_cached_field = create_field_cache(request)
+
+            for hook in self.validating_hooks.values():
+                for validator in hook.validators:
+                    pre_condition_result = self._check_pre_conditions(
+                        validator.name,
+                        validator.pre_conditions,
+                        request,
+                    )
+                    if pre_condition_result is None:
+                        continue
+                    if pre_condition_result is False:
+                        return ValidationResult(
+                            allowed=False,
+                            message=f"Validation pre-condition rejected by '{validator.name}'",
+                        )
+
+                    kwargs = self._extract_validator_kwargs(validator, get_cached_field)
+                    validator_result = self._run_validator(validator, kwargs)
+                    if not validator_result.allowed:
+                        return validator_result
+
+            allowed = True
+            return ValidationResult(allowed=True)
+        except Exception:  # noqa: BLE001
+            errored = True
+            raise
+        finally:
+            self.metrics.observe(
+                kind=kind,
+                operation=operation,
+                allowed=allowed,
+                errored=errored,
+                latency_seconds=time.perf_counter() - start,
+            )
 
     def validate_request(self, request: dict[str, Any]) -> bool:
-        """Evaluate all validating hooks against the request"""
-        # Validate input request structure
-        validate_request_structure(request)
-        
-        field_cache, get_cached_field = create_field_cache(request)
-        
-        for hook in self.validating_hooks.values():
-            for validator in hook.validators:
-                # Check pre-conditions first
-                if not self._check_pre_conditions(validator, request):
-                    return False
-
-                # Extract kwargs for the validator
-                kwargs = self._extract_validator_kwargs(validator, get_cached_field)
-
-                # Run the validator
-                if not self._run_validator(validator, kwargs):
-                    return False
-        
-        return True
+        """Evaluate all validating hooks against the request."""
+        return self.validate_request_detailed(request).allowed
 
     def validate(self, request: dict[str, Any]) -> bool:
-        """
-        Alias for validate_request() for backward compatibility.
-        
-        Args:
-            request: Admission request dictionary
-            
-        Returns:
-            Boolean indicating if validation passed
-        """
+        """Alias for validate_request() for backward compatibility."""
         return self.validate_request(request)
 
+    def mutate_request_detailed(self, request: dict[str, Any]) -> MutationResult:
+        """Apply all matching mutating hooks to a request object."""
+        kind, operation = self._request_labels(request)
+        start = time.perf_counter()
+        allowed = False
+        errored = False
+
+        try:
+            validate_request_structure(request)
+            current_request = copy.deepcopy(request)
+
+            for hook in self.mutating_hooks.values():
+                for mutator in hook.mutators:
+                    pre_condition_result = self._check_pre_conditions(
+                        mutator.name,
+                        mutator.pre_conditions,
+                        current_request,
+                    )
+                    if pre_condition_result is None:
+                        continue
+                    if pre_condition_result is False:
+                        return MutationResult(
+                            allowed=False,
+                            mutated_object=current_request["object"],
+                            message=f"Mutation pre-condition rejected by '{mutator.name}'",
+                        )
+
+                    _, get_cached_field = create_field_cache(current_request)
+                    kwargs = self._extract_validator_kwargs(mutator, get_cached_field)
+                    mutation_result = self._run_mutator(
+                        mutator,
+                        kwargs,
+                        current_request["object"],
+                    )
+                    if not mutation_result.allowed:
+                        return mutation_result
+                    current_request["object"] = mutation_result.mutated_object
+
+            allowed = True
+            return MutationResult(allowed=True, mutated_object=current_request["object"])
+        except Exception:  # noqa: BLE001
+            errored = True
+            raise
+        finally:
+            self.metrics.observe(
+                kind=kind,
+                operation=operation,
+                allowed=allowed,
+                errored=errored,
+                latency_seconds=time.perf_counter() - start,
+            )
+
+    def mutate_request(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Apply mutators and return the mutated object."""
+        result = self.mutate_request_detailed(request)
+        if not result.allowed:
+            raise ValueError(result.message or "Mutation failed")
+        return result.mutated_object
+
+    def mutate(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Alias for mutate_request() for backward compatibility."""
+        return self.mutate_request(request)
+
     def process_admission_review(self, admission_review: dict[str, Any]) -> dict[str, Any]:
-        """
-        Process a Kubernetes AdmissionReview request and return AdmissionReview response.
-        
-        This method accepts a complete AdmissionReview object (as sent by Kubernetes API server),
-        processes it through the validation pipeline, and returns a properly formatted
-        AdmissionReview response.
-        
-        Args:
-            admission_review: Full AdmissionReview object from Kubernetes with structure:
-                {
-                    "apiVersion": "admission.k8s.io/v1",
-                    "kind": "AdmissionReview",
-                    "request": {
-                        "uid": "...",
-                        "kind": {...},
-                        "object": {...},
-                        "oldObject": {...},
-                        "operation": "CREATE|UPDATE|DELETE|CONNECT",
-                        "userInfo": {...},
-                        ...
-                    }
-                }
-            
-        Returns:
-            AdmissionReview response with proper Kubernetes format:
-                {
-                    "apiVersion": "admission.k8s.io/v1",
-                    "kind": "AdmissionReview",
-                    "response": {
-                        "uid": "...",
-                        "allowed": true/false,
-                        "status": {  # only present when allowed=false
-                            "message": "Validation failed: reason"
-                        }
-                    }
-                }
-        
-        Examples:
-            >>> review = {
-            ...     "apiVersion": "admission.k8s.io/v1",
-            ...     "kind": "AdmissionReview",
-            ...     "request": {
-            ...         "uid": "abc-123",
-            ...         "operation": "CREATE",
-            ...         "object": {
-            ...             "kind": "Pod",
-            ...             "apiVersion": "v1",
-            ...             "metadata": {"name": "test-pod"}
-            ...         }
-            ...     }
-            ... }
-            >>> registry = Registry()
-            >>> response = registry.process_admission_review(review)
-            >>> response["response"]["allowed"]
-            True
-        """
+        """Process a validating AdmissionReview request."""
         request = admission_review.get("request", {})
         uid = request.get("uid", "")
-        
-        # Extract the admission request data in the format expected by validate_request
+
         admission_request = {
             "object": request.get("object", {}),
             "oldObject": request.get("oldObject"),
             "operation": request.get("operation", ""),
             "userInfo": request.get("userInfo", {}),
         }
-        
-        # Run validation
+
         try:
-            is_valid = self.validate_request(admission_request)
-            
+            result = self.validate_request_detailed(admission_request)
             response = {
                 "apiVersion": "admission.k8s.io/v1",
                 "kind": "AdmissionReview",
                 "response": {
                     "uid": uid,
-                    "allowed": is_valid
-                }
+                    "allowed": result.allowed,
+                },
             }
-            
-            if not is_valid:
+
+            if not result.allowed:
                 response["response"]["status"] = {
-                    "message": "Validation failed"
+                    "message": result.message or "Validation failed",
                 }
-            
+
             return response
-            
-        except Exception as e:
-            # On error, reject the request and include error message
+        except Exception as exc:  # noqa: BLE001
             return {
                 "apiVersion": "admission.k8s.io/v1",
                 "kind": "AdmissionReview",
@@ -235,10 +564,65 @@ class Registry:
                     "uid": uid,
                     "allowed": False,
                     "status": {
-                        "message": f"Validation error: {str(e)}"
-                    }
-                }
+                        "message": f"Validation error: {exc}",
+                    },
+                },
             }
+
+    def process_mutating_admission_review(self, admission_review: dict[str, Any]) -> dict[str, Any]:
+        """Process a mutating AdmissionReview request and return JSONPatch response."""
+        request = admission_review.get("request", {})
+        uid = request.get("uid", "")
+        request_object = request.get("object", {})
+
+        admission_request = {
+            "object": request_object,
+            "oldObject": request.get("oldObject"),
+            "operation": request.get("operation", ""),
+            "userInfo": request.get("userInfo", {}),
+        }
+
+        try:
+            result = self.mutate_request_detailed(admission_request)
+            response = {
+                "apiVersion": "admission.k8s.io/v1",
+                "kind": "AdmissionReview",
+                "response": {
+                    "uid": uid,
+                    "allowed": result.allowed,
+                },
+            }
+
+            if not result.allowed:
+                response["response"]["status"] = {
+                    "message": result.message or "Mutation failed",
+                }
+                return response
+
+            patch = _create_json_patch(request_object, result.mutated_object)
+            encoded_patch = base64.b64encode(
+                json.dumps(patch, separators=(",", ":")).encode("utf-8")
+            ).decode("utf-8")
+
+            response["response"]["patchType"] = "JSONPatch"
+            response["response"]["patch"] = encoded_patch
+            return response
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "apiVersion": "admission.k8s.io/v1",
+                "kind": "AdmissionReview",
+                "response": {
+                    "uid": uid,
+                    "allowed": False,
+                    "status": {
+                        "message": f"Mutation error: {exc}",
+                    },
+                },
+            }
+
+    def metrics_text(self) -> str:
+        """Render metrics in Prometheus exposition format."""
+        return self.metrics.render_prometheus()
 
 
 REGISTRY = Registry()

--- a/kube_cerberus/webhook_config.py
+++ b/kube_cerberus/webhook_config.py
@@ -1,0 +1,187 @@
+"""Webhook configuration generation utilities."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+from .registry import Mutator, Registry, Validator
+
+
+def _pluralize_kind(kind: str) -> str:
+    normalized = kind.strip().lower()
+    if normalized.endswith("s"):
+        return f"{normalized}es"
+    if normalized.endswith("y") and len(normalized) > 1 and normalized[-2] not in "aeiou":
+        return f"{normalized[:-1]}ies"
+    return f"{normalized}s"
+
+
+def _as_string_filter(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _to_operations(value: Any) -> set[str]:
+    filter_value = _as_string_filter(value)
+    if filter_value is None:
+        return {"*"}
+    return {filter_value.upper()}
+
+
+def _to_resources(value: Any) -> set[str]:
+    filter_value = _as_string_filter(value)
+    if filter_value is None:
+        return {"*"}
+    return {_pluralize_kind(filter_value)}
+
+
+def _to_groups_and_versions(value: Any) -> tuple[set[str], set[str]]:
+    filter_value = _as_string_filter(value)
+    if filter_value is None:
+        return {"*"}, {"*"}
+
+    if "/" in filter_value:
+        group, version = filter_value.split("/", 1)
+        return {group}, {version}
+
+    return {""}, {filter_value}
+
+
+def _collect_rule_values(hooks: Iterable[Validator | Mutator]) -> dict[str, list[str]]:
+    operations: set[str] = set()
+    api_groups: set[str] = set()
+    api_versions: set[str] = set()
+    resources: set[str] = set()
+
+    for hook in hooks:
+        operations.update(_to_operations(hook.operation_filter))
+        resources.update(_to_resources(hook.kind_filter))
+        groups, versions = _to_groups_and_versions(hook.api_version_filter)
+        api_groups.update(groups)
+        api_versions.update(versions)
+
+    if not operations:
+        operations = {"*"}
+    if not api_groups:
+        api_groups = {"*"}
+    if not api_versions:
+        api_versions = {"*"}
+    if not resources:
+        resources = {"*"}
+
+    return {
+        "operations": sorted(operations),
+        "api_groups": sorted(api_groups),
+        "api_versions": sorted(api_versions),
+        "resources": sorted(resources),
+    }
+
+
+def _render_list(values: list[str], indent: int) -> list[str]:
+    space = " " * indent
+    return [f"{space}- {value}" for value in values]
+
+
+def _render_webhook_config(
+    *,
+    config_kind: str,
+    name: str,
+    url: str,
+    ca_bundle: str | None,
+    rule_values: dict[str, list[str]],
+) -> str:
+    webhook_name = re.sub(r"[^a-z0-9.-]", "-", name.lower()).strip("-")
+    webhook_name = webhook_name or "cerberus-webhook"
+
+    lines = [
+        "apiVersion: admissionregistration.k8s.io/v1",
+        f"kind: {config_kind}",
+        "metadata:",
+        f"  name: {webhook_name}",
+        "webhooks:",
+        f"  - name: {webhook_name}.kube-cerberus.local",
+        "    admissionReviewVersions:",
+        "      - v1",
+        "    sideEffects: None",
+        "    failurePolicy: Fail",
+        "    timeoutSeconds: 10",
+        "    clientConfig:",
+        f"      url: {url}",
+    ]
+
+    if ca_bundle:
+        lines.append(f"      caBundle: {ca_bundle}")
+
+    lines.extend(
+        [
+            "    rules:",
+            "      - operations:",
+            *_render_list(rule_values["operations"], 10),
+            "        apiGroups:",
+            *_render_list(rule_values["api_groups"], 10),
+            "        apiVersions:",
+            *_render_list(rule_values["api_versions"], 10),
+            "        resources:",
+            *_render_list(rule_values["resources"], 10),
+        ]
+    )
+    return "\n".join(lines)
+
+
+def generate_webhook_configuration_yaml(
+    *,
+    registry: Registry,
+    url: str,
+    name: str = "cerberus-webhook",
+    mode: str = "validating",
+    ca_bundle: str | None = None,
+) -> str:
+    """
+    Generate Kubernetes webhook configuration YAML from registered hooks.
+
+    Args:
+        registry: Registry containing registered hooks.
+        url: Webhook URL reachable by Kubernetes API server.
+        name: Base metadata.name for generated resources.
+        mode: One of validating, mutating, or both.
+        ca_bundle: Optional base64-encoded CA bundle.
+    """
+    normalized_mode = mode.strip().lower()
+    if normalized_mode not in {"validating", "mutating", "both"}:
+        raise ValueError("mode must be one of: validating, mutating, both")
+
+    documents: list[str] = []
+
+    if normalized_mode in {"validating", "both"}:
+        validators = [
+            validator
+            for hook in registry.validating_hooks.values()
+            for validator in hook.validators
+        ]
+        validating_rules = _collect_rule_values(validators)
+        documents.append(
+            _render_webhook_config(
+                config_kind="ValidatingWebhookConfiguration",
+                name=f"{name}-validating",
+                url=url,
+                ca_bundle=ca_bundle,
+                rule_values=validating_rules,
+            )
+        )
+
+    if normalized_mode in {"mutating", "both"}:
+        mutators = [mutator for hook in registry.mutating_hooks.values() for mutator in hook.mutators]
+        mutating_rules = _collect_rule_values(mutators)
+        documents.append(
+            _render_webhook_config(
+                config_kind="MutatingWebhookConfiguration",
+                name=f"{name}-mutating",
+                url=url,
+                ca_bundle=ca_bundle,
+                rule_values=mutating_rules,
+            )
+        )
+
+    return "\n---\n".join(documents) + "\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ dependencies = [
     # Core admission validation has no external dependencies
 ]
 
+[project.scripts]
+cerberus = "kube_cerberus.cli:main"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",

--- a/tests/unit_tests/todo_features_test.py
+++ b/tests/unit_tests/todo_features_test.py
@@ -1,0 +1,235 @@
+import base64
+import json
+import logging
+
+import pytest
+
+from kube_cerberus.cli import main as cli_main
+from kube_cerberus.registry import REGISTRY, Registry, Validator, ValidatingHook
+from kube_cerberus.validator import mutating, validating
+from kube_cerberus.webhook_config import generate_webhook_configuration_yaml
+
+
+def _pod_request() -> dict:
+    return {
+        "object": {
+            "kind": "Pod",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "test-pod",
+                "namespace": "default",
+                "labels": {"app": "demo"},
+            },
+            "spec": {"containers": [{"name": "app", "image": "nginx:alpine"}]},
+        },
+        "operation": "CREATE",
+        "userInfo": {"username": "dev-user"},
+    }
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    REGISTRY.validating_hooks.clear()
+    REGISTRY.mutating_hooks.clear()
+    REGISTRY.metrics = type(REGISTRY.metrics)()
+    yield
+    REGISTRY.validating_hooks.clear()
+    REGISTRY.mutating_hooks.clear()
+    REGISTRY.metrics = type(REGISTRY.metrics)()
+
+
+def test_validation_message_details_are_returned_in_admission_response():
+    @validating("pod-label-validator", kind="Pod")
+    def validate_pod(labels):
+        if "required" not in labels:
+            return False, "Pod must include 'required' label"
+        return True, ""
+
+    review = {
+        "apiVersion": "admission.k8s.io/v1",
+        "kind": "AdmissionReview",
+        "request": {
+            "uid": "uid-1",
+            "operation": "CREATE",
+            "object": _pod_request()["object"],
+        },
+    }
+
+    response = REGISTRY.process_admission_review(review)
+    assert response["response"]["allowed"] is False
+    assert response["response"]["status"]["message"] == "Pod must include 'required' label"
+
+
+def test_async_validator_is_supported():
+    @validating("async-validator", kind="Pod")
+    async def validate_async(labels):
+        return "app" in labels
+
+    assert REGISTRY.validate_request(_pod_request()) is True
+
+
+def test_pre_condition_mismatch_skips_validator():
+    @validating("service-only", kind="Service")
+    def validate_service():
+        return False
+
+    assert REGISTRY.validate_request(_pod_request()) is True
+
+
+def test_explicit_pre_condition_failure_rejects_request():
+    registry = Registry()
+
+    def always_reject(_request):
+        return False
+
+    validator = Validator(
+        pre_conditions=[always_reject],
+        user_function=lambda: True,
+        name="explicit-reject",
+        extract_fields={},
+    )
+    registry.add_validating_webhook(
+        ValidatingHook(name="explicit-reject", validators=[validator])
+    )
+
+    assert registry.validate_request(_pod_request()) is False
+
+
+def test_mutating_hook_changes_object():
+    @mutating("add-managed-label", kind="Pod")
+    def add_label(object):
+        mutated = dict(object)
+        metadata = dict(mutated.get("metadata", {}))
+        labels = dict(metadata.get("labels", {}))
+        labels["managed-by"] = "cerberus"
+        metadata["labels"] = labels
+        mutated["metadata"] = metadata
+        return mutated
+
+    result = REGISTRY.mutate_request_detailed(_pod_request())
+    assert result.allowed is True
+    assert result.mutated_object["metadata"]["labels"]["managed-by"] == "cerberus"
+
+
+def test_async_mutator_is_supported():
+    @mutating("async-mutator", kind="Pod")
+    async def async_mutate(object):
+        mutated = dict(object)
+        metadata = dict(mutated.get("metadata", {}))
+        metadata["annotations"] = {"mutated": "true"}
+        mutated["metadata"] = metadata
+        return mutated
+
+    result = REGISTRY.mutate_request_detailed(_pod_request())
+    assert result.allowed is True
+    assert result.mutated_object["metadata"]["annotations"]["mutated"] == "true"
+
+
+def test_mutating_admission_review_returns_json_patch():
+    @mutating("add-label", kind="Pod")
+    def add_label(object):
+        mutated = dict(object)
+        metadata = dict(mutated.get("metadata", {}))
+        labels = dict(metadata.get("labels", {}))
+        labels["added-by"] = "cerberus"
+        metadata["labels"] = labels
+        mutated["metadata"] = metadata
+        return mutated
+
+    review = {
+        "apiVersion": "admission.k8s.io/v1",
+        "kind": "AdmissionReview",
+        "request": {
+            "uid": "uid-2",
+            "operation": "CREATE",
+            "object": _pod_request()["object"],
+        },
+    }
+    response = REGISTRY.process_mutating_admission_review(review)
+
+    assert response["response"]["allowed"] is True
+    assert response["response"]["patchType"] == "JSONPatch"
+    patch = json.loads(base64.b64decode(response["response"]["patch"]).decode("utf-8"))
+    assert any(op["path"] == "/metadata/labels/added-by" for op in patch)
+
+
+def test_metrics_include_request_rejection_and_error_counts():
+    registry = Registry()
+
+    validator = Validator(
+        pre_conditions=[],
+        user_function=lambda: False,
+        name="always-fail",
+        extract_fields={},
+    )
+    registry.add_validating_webhook(ValidatingHook(name="always-fail", validators=[validator]))
+
+    assert registry.validate_request(_pod_request()) is False
+
+    with pytest.raises(ValueError):
+        registry.validate_request({"invalid": "request"})
+
+    metrics = registry.metrics_text()
+    assert 'kube_cerberus_requests_total{kind="Pod",operation="CREATE"} 1' in metrics
+    assert 'kube_cerberus_rejections_total{kind="Pod",operation="CREATE"} 1' in metrics
+    assert 'kube_cerberus_errors_total{kind="unknown",operation="unknown"} 1' in metrics
+
+
+def test_non_bool_validator_result_uses_structured_logging(caplog):
+    caplog.set_level(logging.WARNING)
+
+    validator = Validator(
+        pre_conditions=[],
+        user_function=lambda: "not-a-bool",
+        name="bad-validator",
+        extract_fields={},
+    )
+    registry = Registry()
+    registry.add_validating_webhook(ValidatingHook(name="bad-validator", validators=[validator]))
+
+    assert registry.validate_request(_pod_request()) is False
+    assert "returned invalid type" in caplog.text
+
+
+def test_generate_webhook_configuration_yaml_includes_both_modes():
+    @validating("validate-pod", kind="Pod", operation="CREATE", apiVersion="v1")
+    def validate_pod():
+        return True
+
+    @mutating("mutate-pod", kind="Pod", operation="UPDATE", apiVersion="v1")
+    def mutate_pod(object):
+        return object
+
+    output = generate_webhook_configuration_yaml(
+        registry=REGISTRY,
+        url="https://webhook.example.com:8443",
+        name="cerberus",
+        mode="both",
+    )
+
+    assert "kind: ValidatingWebhookConfiguration" in output
+    assert "kind: MutatingWebhookConfiguration" in output
+    assert "url: https://webhook.example.com:8443" in output
+    assert "- pods" in output
+
+
+def test_cli_generate_webhook_outputs_yaml(capsys):
+    @validating("validate-pod", kind="Pod")
+    def validate_pod():
+        return True
+
+    exit_code = cli_main(
+        [
+            "generate-webhook",
+            "--url",
+            "https://webhook.example.com:8443",
+            "--name",
+            "cerberus",
+            "--mode",
+            "validating",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "ValidatingWebhookConfiguration" in captured.out


### PR DESCRIPTION
## Summary
- implement pre-condition tri-state behavior (match/reject/skip) so non-matching validators are skipped
- add mutating webhook framework with @mutating, mutation pipeline, and mutating AdmissionReview JSONPatch responses
- add detailed validator failure messages via (bool, str) return values and async hook support
- add Prometheus metrics export via Registry.metrics_text()
- replace runtime print diagnostics with structured logging
- add webhook configuration generator and CLI: cerberus generate-webhook

## Tests
- update existing unit tests for new pre-condition semantics
- add tests/unit_tests/todo_features_test.py covering mutating hooks, async hooks, detailed messages, metrics, logging, and CLI output
- local results: 64 passed, 6 deselected (pytest -m "not integration")
